### PR TITLE
Remove Intermediate DateTime Types

### DIFF
--- a/Schema/B2MML-Common.xsd
+++ b/Schema/B2MML-Common.xsd
@@ -111,7 +111,7 @@
                                                term in ISA 95, or "EquipmentElementLevel", the older term.
                                              - Added HierarchyScope to TestResultType
 											 - Added documentation of selected elements
-            
+											 - Removed intermediate types for Identifiers and DateTime
 
 
    </xsd:documentation>
@@ -119,23 +119,10 @@
     <!--  - - - - - - - - - - - - - - - - - - - - - - - - - - - - -   -->
     <!--  B2MML Common Component Elements - - - - - - - - - - - - -   -->
     <!--  - - - - - - - - - - - - - - - - - - - - - - - - - - - - -   -->
-    <xsd:complexType name="ActualEndTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
+    
+
     <!--     -->    
-    <xsd:complexType name="ActualFinishTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
-    <!--     -->    
-    <xsd:complexType name="ActualStartTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
+
     <!--     -->    
     <xsd:complexType name="AnyGenericValueType">
         <xsd:simpleContent>
@@ -473,25 +460,14 @@ Defined values are (explained using dependency type between element A and elemen
     <xsd:simpleType name="DurationType">
         <xsd:restriction base="xsd:duration"/>
     </xsd:simpleType>
-    <xsd:complexType name="EarliestStartTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
-    <!--     -->    
-    <xsd:complexType name="EndTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
     <!--     -->    
     <xsd:complexType name="EquipmentAssetMappingType">
         <xsd:sequence>
             <xsd:element name="EquipmentID" type="EquipmentIDType"/>
             <xsd:element name="PhysicalAssetID" type="PhysicalAssetIDType"/>
 			<xsd:element name="HierarchyScope" type = "HierarchyScopeType" minOccurs = "0"/>
-            <xsd:element name="StartTime" type="StartTimeType" minOccurs="0"/>
-            <xsd:element name="EndTime" type="EndTimeType" minOccurs="0"/>
+            <xsd:element name="StartTime" type="DateTimeType" minOccurs="0"/>
+            <xsd:element name="EndTime" type="DateTimeType" minOccurs="0"/>
             <xsd:group ref="Extended:EquipmentAssetMapping" minOccurs="0" maxOccurs="1"/>
         </xsd:sequence>
     </xsd:complexType>
@@ -578,12 +554,6 @@ Defined values are:
                                                         minOccurs = "0" maxOccurs = "1"/>
           </xsd:sequence>
         </xsd:complexType>
-    <!--     -->    
-    <xsd:complexType name="ExpirationTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
     <!--     -->    
     <xsd:complexType name="HierarchyScopeType">
 		<xsd:annotation> 
@@ -699,12 +669,6 @@ Defined values are
     </xsd:complexType>
 
     
-    <!--     -->    
-    <xsd:complexType name="LatestEndTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
     <!--     -->    
     <!--  LocationType kept in V05 for use with the Production element definitions. Not used in other elements.  -->
     <xsd:complexType name="LocationType">
@@ -1093,8 +1057,8 @@ Defined values for inventory operations defined values are
 			<xsd:element name="SpatialDefinition" type="SpatialDefinitionType" minOccurs = "0" />
 			<xsd:element name="OperationalLocation" type="ResourceLocationType" minOccurs = "0" />
             <xsd:element name="PersonnelUse" type="PersonnelUseType" minOccurs="0"/>
-            <xsd:element name="StartTime" type="StartTimeType" minOccurs="0"/>
-            <xsd:element name="EndTime" type="EndTimeType" minOccurs="0"/>
+            <xsd:element name="StartTime" type="DateTimeType" minOccurs="0"/>
+            <xsd:element name="EndTime" type="DateTimeType" minOccurs="0"/>
             <xsd:element name="Quantity" type="QuantityValueType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="PersonnelCapability" type="OpPersonnelCapabilityType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="PersonnelCapabilityProperty" type="OpPersonnelCapabilityPropertyType" minOccurs="0" maxOccurs="unbounded"/>
@@ -1125,8 +1089,8 @@ Defined values for inventory operations defined values are
 			<xsd:element name="SpatialDefinition" type="SpatialDefinitionType" minOccurs = "0" />
 			<xsd:element name="OperationalLocation" type="ResourceLocationType" minOccurs = "0" />
             <xsd:element name="EquipmentUse" type="EquipmentUseType" minOccurs="0"/>
-            <xsd:element name="StartTime" type="StartTimeType" minOccurs="0"/>
-            <xsd:element name="EndTime" type="EndTimeType" minOccurs="0"/>
+            <xsd:element name="StartTime" type="DateTimeType" minOccurs="0"/>
+            <xsd:element name="EndTime" type="DateTimeType" minOccurs="0"/>
             <xsd:element name="Quantity" type="QuantityValueType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="EquipmentCapability" type="OpEquipmentCapabilityType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="EquipmentCapabilityProperty" type="OpEquipmentCapabilityPropertyType" minOccurs="0" maxOccurs="unbounded"/>
@@ -1157,8 +1121,8 @@ Defined values for inventory operations defined values are
 			<xsd:element name="SpatialDefinition" type="SpatialDefinitionType" minOccurs = "0" />
 			<xsd:element name="PhysicalLocation" type="ResourceLocationType" minOccurs = "0" />
             <xsd:element name="PhysicalAssetUse" type="PhysicalAssetUseType" minOccurs="0"/>
-            <xsd:element name="StartTime" type="StartTimeType" minOccurs="0"/>
-            <xsd:element name="EndTime" type="EndTimeType" minOccurs="0"/>
+            <xsd:element name="StartTime" type="DateTimeType" minOccurs="0"/>
+            <xsd:element name="EndTime" type="DateTimeType" minOccurs="0"/>
             <xsd:element name="Quantity" type="QuantityValueType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="PhysicalAssetCapability" type="OpPhysicalAssetCapabilityType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="PhysicalAssetCapabilityProperty" type="OpPhysicalAssetCapabilityPropertyType" minOccurs="0" maxOccurs="unbounded"/>
@@ -1191,8 +1155,8 @@ Defined values for inventory operations defined values are
             <xsd:element name="MaterialUse" type="MaterialUseType" minOccurs="0"/>
 			<xsd:element name="SpatialDefinition" type="SpatialDefinitionType" minOccurs = "0" />
 			<xsd:element name="StorageLocation" type="ResourceLocationType" minOccurs = "0" />
-            <xsd:element name="StartTime" type="StartTimeType" minOccurs="0"/>
-            <xsd:element name="EndTime" type="EndTimeType" minOccurs="0"/>
+            <xsd:element name="StartTime" type="DateTimeType" minOccurs="0"/>
+            <xsd:element name="EndTime" type="DateTimeType" minOccurs="0"/>
             <xsd:element name="AssemblyCapability" type="OpMaterialCapabilityType" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="AssemblyType" type="AssemblyTypeType" minOccurs="0"/>
             <xsd:element name="AssemblyRelationship" type="AssemblyRelationshipType" minOccurs="0"/>
@@ -1349,18 +1313,6 @@ Defined values are
         </xsd:simpleContent>
     </xsd:complexType>
     <!--     -->    
-    <xsd:complexType name="PlannedFinishTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
-    <!--     -->    
-    <xsd:complexType name="PlannedStartTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
-    <!--     -->    
     <xsd:complexType name="PriorityType">
         <xsd:simpleContent>
             <xsd:restriction base="NumericType"/>
@@ -1419,12 +1371,6 @@ Defined values are
     <xsd:complexType name="PropertyIDType">
         <xsd:simpleContent>
             <xsd:restriction base="IdentifierType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
-    <!--     -->    
-    <xsd:complexType name="PublishedDateType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
         </xsd:simpleContent>
     </xsd:complexType>
     <!--     -->    
@@ -1489,12 +1435,6 @@ Defined values are
             <xsd:extension base="RelationshipType1Type">
                 <xsd:attribute name="OtherValue" type="xsd:string"/>
             </xsd:extension>
-        </xsd:simpleContent>
-    </xsd:complexType>
-    <!--     -->    
-    <xsd:complexType name="RequestedCompletionDateType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
         </xsd:simpleContent>
     </xsd:complexType>
     <!--     -->    
@@ -1761,18 +1701,6 @@ Spatial definition identifies a value and the predefined coordinate reference sy
         </xsd:sequence>
     </xsd:complexType>
      <!--     -->    
-    <xsd:complexType name="StartTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
-    <!--     -->    
-    <xsd:complexType name="StatusTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
-    <!--     -->    
     <xsd:complexType name="StatusType">
         <xsd:simpleContent>
             <xsd:restriction base="CodeType"/>
@@ -1785,13 +1713,7 @@ Spatial definition identifies a value and the predefined coordinate reference sy
         </xsd:simpleContent>
     </xsd:complexType>
     <!--     -->    
-    <xsd:complexType name="TestDateTimeType">
-        <xsd:simpleContent>
-            <xsd:restriction base="DateTimeType"/>
-        </xsd:simpleContent>
-    </xsd:complexType>
-    <!--     -->    
- 	
+	
 	<xsd:complexType name = "TestResultType">
 		<xsd:sequence>
 			<xsd:element name = "ID" type = "IdentifierType" minOccurs = "0" nillable="true"/>

--- a/Schema/B2MML-Equipment.xsd
+++ b/Schema/B2MML-Equipment.xsd
@@ -83,6 +83,7 @@
 											    Added EquipmentCapabilityTestSpecificationID to Equipment and EquipmentClass
         V0600   17 Mar 2013     D. Brandl       Changed copyright to MESA International and support for ISA 95 Part 4                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version to match the 2018 ISA 95 update
+												Changed all intermediate date and time types to DatTimeType
  
 
    </xsd:documentation>
@@ -153,7 +154,7 @@ zero or more equipment classes.
                                                 minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "HierarchyScope"      type = "HierarchyScopeType"
                                                 minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"       type = "PublishedDateType"
+      <xsd:element name = "PublishedDate"       type = "DateTimeType"
                                                 minOccurs = "0"/>
       <xsd:element name = "Equipment"           type = "EquipmentType"  
                                                 minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/B2MML-MasterDataProfile.xsd
+++ b/Schema/B2MML-MasterDataProfile.xsd
@@ -51,6 +51,7 @@
         Ver     Date            Person          Note
         ---     ----            ------          ----
         7.0		12-Dec-2018		Dennis Brandl	Initial  version for a Base Data Exchange Profile                                
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>

--- a/Schema/B2MML-Material.xsd
+++ b/Schema/B2MML-Material.xsd
@@ -86,6 +86,7 @@
 											    Changed "Location" element name to "HierarchyScope"
         V0600   17 Mar 2013     D. Brandl       Changed copyright to MESA International and support for ISA 95 Part 4                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version
+												Changed all intermediate date and time types to DatTimeType
  
    </xsd:documentation>
 </xsd:annotation>
@@ -159,7 +160,7 @@
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"    
                                                         minOccurs = "0"  nillable="true"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"  nillable="true"/>
       <xsd:element name = "MaterialClass"               type = "MaterialClassType"      
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>

--- a/Schema/B2MML-OperationalLocation.xsd
+++ b/Schema/B2MML-OperationalLocation.xsd
@@ -54,7 +54,8 @@
 
         Ver     Date            Person          Note
         ---     ----            ------          ----
-       V0700   09 Nov 2018     D. Brandl      Initial Version fro 2018 ISA 95 Part 2 update
+       V0700   09 Nov 2018     D. Brandl        Initial Version fro 2018 ISA 95 Part 2 update
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -131,7 +132,7 @@ may be made up of other operational locations.
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"    
                                                         minOccurs = "0"  nillable="true"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"  nillable="true"/>
       <xsd:element name = "OperationalLocationClass"    type = "OperationalLocationClassType"      
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>

--- a/Schema/B2MML-OperationsCapability.xsd
+++ b/Schema/B2MML-OperationsCapability.xsd
@@ -57,6 +57,7 @@
         V0500   26 Mar 2011     D. Brandl      New version
         V0600   17 Mar 2013     D. Brandl      Changed copyright to MESA International and support for ISA 95 Part 4                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 2
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -96,7 +97,7 @@
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"    
                                                         minOccurs = "0"  nillable="true"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"  nillable="true"/>
       <xsd:element name = "OperationsCapability"        type = "OperationsCapabilityType"      
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>
@@ -119,11 +120,11 @@
                                                     minOccurs = "0"/>
       <xsd:element name = "ConfidenceFactor"        type = "ConfidenceFactorType"
                                                     minOccurs = "0"/>
-      <xsd:element name = "StartTime"               type = "StartTimeType"
+      <xsd:element name = "StartTime"               type = "DateTimeType"
                                                     minOccurs = "0"/>
-      <xsd:element name = "EndTime"                 type = "EndTimeType"
+      <xsd:element name = "EndTime"                 type = "DateTimeType"
                                                     minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"           type = "PublishedDateType"
+      <xsd:element name = "PublishedDate"           type = "DateTimeType"
                                                     minOccurs = "0"/>
       <xsd:element name = "PersonnelCapability"     type = "OpPersonnelCapabilityType" 
                                                     minOccurs = "0" maxOccurs = "unbounded"/>
@@ -158,9 +159,9 @@
                                                     minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "EquipmentElementLevel"   type = "EquipmentElementLevelType" 
                                                     minOccurs = "0" maxOccurs = "unbounded"/>
-      <xsd:element name = "StartTime"               type = "StartTimeType"
+      <xsd:element name = "StartTime"               type = "DateTimeType"
                                                     minOccurs = "0"/>
-      <xsd:element name = "EndTime"                 type = "EndTimeType"
+      <xsd:element name = "EndTime"                 type = "DateTimeType"
                                                     minOccurs = "0"/>
       <xsd:element name = "PersonnelCapability"     type = "OpPersonnelCapabilityType" 
                                                     minOccurs = "0" maxOccurs = "unbounded"/>
@@ -192,9 +193,9 @@
                                                     minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "EquipmentElementLevel"   type = "EquipmentElementLevelType" 
                                                     minOccurs = "0" maxOccurs = "unbounded"/>
-      <xsd:element name = "StartTime"               type = "StartTimeType"
+      <xsd:element name = "StartTime"               type = "DateTimeType"
                                                     minOccurs = "0"/>
-      <xsd:element name = "EndTime"                 type = "EndTimeType"
+      <xsd:element name = "EndTime"                 type = "DateTimeType"
                                                     minOccurs = "0"/>
       <xsd:element name = "PersonnelCapability"     type = "OpPersonnelCapabilityType" 
                                                     minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/B2MML-OperationsDefinition.xsd
+++ b/Schema/B2MML-OperationsDefinition.xsd
@@ -64,6 +64,7 @@
 												Added Test Specification ID to resource specifications
 												Added Work Master links
 												Added transactions for Operations Segment, not in Part 5, but discussed in ISA 95 meetings
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -114,7 +115,7 @@
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"
 														minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
 														minOccurs = "0"/>
       <xsd:element name = "OperationsDefinition"        type = "OperationsDefinitionType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
@@ -135,7 +136,7 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "OperationsType"              type = "OperationsTypeType" 
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType"     
+      <xsd:element name = "PublishedDate"               type = "DateTimeType"     
                                                         minOccurs = "0"/>
       <xsd:element name = "BillOfMaterialsID"           type = "BillOfMaterialsIDType" 
                                                         minOccurs = "0"/>

--- a/Schema/B2MML-OperationsEvent.xsd
+++ b/Schema/B2MML-OperationsEvent.xsd
@@ -59,6 +59,7 @@
         Ver     Date            Person          Note
         ---     ----            ------          ----
         V0700   09 Nov 2018     D. Brandl       Initial Version
+												Changed all intermediate date and time types to DatTimeType
  
    </xsd:documentation>
 </xsd:annotation>
@@ -162,7 +163,7 @@ function or activity.
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"    
                                                         minOccurs = "0"  nillable="true"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"  nillable="true"/>
       <xsd:element name = "OperationsEventClass"        type = "OperationsEventClassType"      
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>

--- a/Schema/B2MML-OperationsPerformance.xsd
+++ b/Schema/B2MML-OperationsPerformance.xsd
@@ -58,6 +58,7 @@
         V0600   17 Mar 2013     D. Brandl       Changed copyright to MESA International and support for ISA 95 Part 4                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 2
                                                 Added OperationsSegmentID to OperationsResponseType
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -92,13 +93,13 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "OperationsScheduleID"        type = "OperationsScheduleIDType"       
                                                         minOccurs = "0"/>
-      <xsd:element name = "StartTime"                   type = "StartTimeType"                  
+      <xsd:element name = "StartTime"                   type = "DateTimeType"                  
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "EndTimeType"    
+      <xsd:element name = "EndTime"                     type = "DateTimeType"    
                                                         minOccurs = "0"/>
       <xsd:element name = "PerformanceState"            type = "ResponseStateType"
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"/>
       <xsd:element name = "OperationsResponse"          type = "OperationsResponseType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
@@ -121,9 +122,9 @@
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "SegmentRequirementID"        type = "SegmentRequirementIDType"  
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
-      <xsd:element name = "StartTime"                   type = "StartTimeType"          
+      <xsd:element name = "StartTime"                   type = "DateTimeType"          
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "EndTimeType"    
+      <xsd:element name = "EndTime"                     type = "DateTimeType"    
                                                         minOccurs = "0"/>
       <xsd:element name = "OperationsDefinitionID"      type = "OperationsDefinitionIDType"    
                                                         minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/B2MML-OperationsPerformanceTypes.xsd
+++ b/Schema/B2MML-OperationsPerformanceTypes.xsd
@@ -75,9 +75,9 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "ProcessSegmentID"            type = "ProcessSegmentIDType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
-      <xsd:element name = "ActualStartTime"             type = "ActualStartTimeType"    
+      <xsd:element name = "ActualStartTime"             type = "DateTimeType"    
                                                         minOccurs = "0"/>
-      <xsd:element name = "ActualEndTime"               type = "ActualEndTimeType"      
+      <xsd:element name = "ActualEndTime"               type = "DateTimeType"      
                                                         minOccurs = "0"/>
       <xsd:element name = "PostingDate"                 type = "DateTimeType"      
                                                         minOccurs = "0"/>

--- a/Schema/B2MML-OperationsSchedule.xsd
+++ b/Schema/B2MML-OperationsSchedule.xsd
@@ -95,13 +95,13 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "OperationsType"              type = "OperationsTypeType"   
                                                         minOccurs = "0"/>
-      <xsd:element name = "StartTime"                   type = "StartTimeType"   
+      <xsd:element name = "StartTime"                   type = "DateTimeType"   
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "EndTimeType"     
+      <xsd:element name = "EndTime"                     type = "DateTimeType"     
                                                         minOccurs = "0"/>
       <xsd:element name = "ScheduleState"               type = "RequestStateType"
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"/>
       <xsd:element name = "OperationsRequest"           type = "OperationsRequestType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
@@ -119,9 +119,9 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "OperationsType"              type = "OperationsTypeType"   
                                                         minOccurs = "0"/>
-      <xsd:element name = "StartTime"                   type = "StartTimeType" 
+      <xsd:element name = "StartTime"                   type = "DateTimeType" 
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "EndTimeType" 
+      <xsd:element name = "EndTime"                     type = "DateTimeType" 
                                                         minOccurs = "0"/>
       <xsd:element name = "Priority"                    type = "PriorityType" 
                                                         minOccurs = "0"/>
@@ -151,9 +151,9 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "ProcessSegmentID"            type = "ProcessSegmentIDType" 
 	                                                    minOccurs = "0"/>
-      <xsd:element name = "EarliestStartTime"           type = "EarliestStartTimeType"  
+      <xsd:element name = "EarliestStartTime"           type = "DateTimeType"  
                                                         minOccurs = "0"/>
-      <xsd:element name = "LatestEndTime"               type = "LatestEndTimeType"      
+      <xsd:element name = "LatestEndTime"               type = "DateTimeType"      
                                                         minOccurs = "0"/>
       <xsd:element name = "Duration"                    type = "DurationType"           
                                                         minOccurs = "0"/>

--- a/Schema/B2MML-Personnel.xsd
+++ b/Schema/B2MML-Personnel.xsd
@@ -153,7 +153,7 @@ A person may be a member of zero or more personnel classes.
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
 			<xsd:element name = "HierarchyScope"        type = "HierarchyScopeType"    
                                                         minOccurs = "0"/>
-			<xsd:element name = "PublishedDate"         type = "PublishedDateType" 
+			<xsd:element name = "PublishedDate"         type = "DateTimeType" 
                                                         minOccurs = "0"/>
             <xsd:element name = "Person"                type = "PersonType"     
                                                         minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/B2MML-PhysicalAsset.xsd
+++ b/Schema/B2MML-PhysicalAsset.xsd
@@ -64,6 +64,7 @@
         V0600   17 Mar 2013     D. Brandl       Changed copyright to MESA International and support for ISA 95 Part 4                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 2
 												Removed PhysicalAsseteCapabilityTestSpecification definitions, replaced by TestSpecification model
+												Changed all intermediate date and time types to DatTimeType
    </xsd:documentation>
 </xsd:annotation>
 
@@ -144,7 +145,7 @@ A physical asset class may be made up of zero or more physical asset classes.
                                                 minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "HierarchyScope"      type = "HierarchyScopeType"
                                                 minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"       type = "PublishedDateType"
+      <xsd:element name = "PublishedDate"       type = "DateTimeType"
                                                 minOccurs = "0"/>
       <xsd:element name = "PhysicalAsset"       type = "PhysicalAssetType"  
                                                 minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/B2MML-ProcessSegment.xsd
+++ b/Schema/B2MML-ProcessSegment.xsd
@@ -80,6 +80,7 @@
 												Added PhysicalAsset elements
         V0600   17 Mar 2013     D. Brandl       Changed copyright to MESA International and support for ISA 95 Part 4                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 2
+												Changed all intermediate date and time types to DatTimeType
 
 
         </xsd:documentation>
@@ -137,7 +138,7 @@ referenced work master shall have the same value as that of the process segment.
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType"
+      <xsd:element name = "PublishedDate"               type = "DateTimeType"
                                                         minOccurs = "0"/>
       <xsd:element name = "ProcessSegment"              type = "ProcessSegmentType"
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
@@ -154,8 +155,7 @@ referenced work master shall have the same value as that of the process segment.
       <xsd:element name = "OperationsType"              type = "OperationsTypeType" minOccurs = "0"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType" minOccurs = "0"/>
       <xsd:element name = "DefinitionType"              type = "DefinitionTypeType" minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType"  minOccurs = "0"/>
-      <xsd:element name = "Duration"                    type = "DurationType"       minOccurs = "0"/>
+      <xsd:element name = "PublishedDate"               type = "DateTimeType"       minOccurs = "0"/>
       <xsd:element name = "PersonnelSegmentSpecification"
                                                         type = "PersonnelSegmentSpecificationType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/B2MML-ResourceRelationshipNetwork.xsd
+++ b/Schema/B2MML-ResourceRelationshipNetwork.xsd
@@ -55,6 +55,7 @@
         ---     ----            ------          ----
         V0600   15 Aug 2012     D. Brandl       Initial version with support for ISA 95 Part 4                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 4
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -128,7 +129,7 @@
                                                                  minOccurs = "0"/>
       <xsd:element name = "RelationshipForm"                     type = "RelationshipFormType"    
                                                                  minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"                        type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"                        type = "DateTimeType" 
                                                                  minOccurs = "0"/>
       <xsd:element name = "NetworkProperty"                  	 type = "ResourcePropertyType" 
                                                                  minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/B2MML-TestSpecification.xsd
+++ b/Schema/B2MML-TestSpecification.xsd
@@ -54,7 +54,8 @@
 
         Ver     Date            Person          Note
         ---     ----            ------          ----
-       V0700   09 Nov 2018     D. Brandl      Initial Version from 2018 ISA 95 Part 2 update
+       V0700   09 Nov 2018     D. Brandl        Initial Version from 2018 ISA 95 Part 2 update
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -113,7 +114,7 @@ of test specifications.
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"    
                                                         minOccurs = "0"  nillable="true"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"  nillable="true"/>
       <xsd:element name = "TestSpecification"         	type = "TestSpecificationType"      
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>

--- a/Schema/B2MML-TransactionProfile.xsd
+++ b/Schema/B2MML-TransactionProfile.xsd
@@ -64,6 +64,7 @@
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 2, 4 and 5
 												Included the B2MML "INFORMATION" container objects 
 												Added new objects from Part 4 and Part 4
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -87,7 +88,7 @@
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType"
+      <xsd:element name = "PublishedDate"               type = "DateTimeType"
                                                         minOccurs = "0"/>
       <xsd:element name = "SupportedAction"             type = "SupportedActionType"
                                                         minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/B2MML-WorkAlert.xsd
+++ b/Schema/B2MML-WorkAlert.xsd
@@ -57,6 +57,7 @@
         ---     ----            ------          ----
         V0600   17 Mar 2013     D. Brandl       Initial version                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 4
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -106,7 +107,7 @@
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"    
                                                         minOccurs = "0"  nillable="true"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"  nillable="true"/>
       <xsd:element name = "WorkAlertDefinition"         type = "WorkAlertDefinitionType"      
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>
@@ -144,7 +145,7 @@
                                                     minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "HierarchyScope"          type = "HierarchyScopeType"
                                                     minOccurs = "0"/>
-      <xsd:element name = "TimeStamp"               type = "StartTimeType"
+      <xsd:element name = "TimeStamp"               type = "DateTimeType"
                                                     minOccurs = "0"/>
       <xsd:element name = "Priority"                type = "PriorityType" 
                                                     minOccurs = "0"/>

--- a/Schema/B2MML-WorkCalendar.xsd
+++ b/Schema/B2MML-WorkCalendar.xsd
@@ -57,6 +57,7 @@
         ---     ----            ------          ----
         V0600   17 Mar 2013     D. Brandl       Initial version                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 4
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -106,7 +107,7 @@
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"    
                                                         minOccurs = "0"  nillable="true"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"  nillable="true"/>
       <xsd:element name = "WorkCalendar"                type = "WorkCalendarType"      
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>

--- a/Schema/B2MML-WorkCapability.xsd
+++ b/Schema/B2MML-WorkCapability.xsd
@@ -57,6 +57,7 @@
         ---     ----            ------          ----
         V0600   17 Mar 2013     D. Brandl       Initial version                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 4
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -96,7 +97,7 @@
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"    
                                                         minOccurs = "0"  nillable="true"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"  nillable="true"/>
       <xsd:element name = "WorkCapability"              type = "WorkCapabilityType"      
                                                         minOccurs = "0" maxOccurs = "unbounded"  nillable="true"/>
@@ -119,11 +120,11 @@
                                                     minOccurs = "0"/>
       <xsd:element name = "ConfidenceFactor"        type = "ConfidenceFactorType"
                                                     minOccurs = "0"/>
-      <xsd:element name = "StartTime"               type = "StartTimeType"
+      <xsd:element name = "StartTime"               type = "DateTimeType"
                                                     minOccurs = "0"/>
-      <xsd:element name = "EndTime"                 type = "EndTimeType"
+      <xsd:element name = "EndTime"                 type = "DateTimeType"
                                                     minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"           type = "PublishedDateType"
+      <xsd:element name = "PublishedDate"           type = "DateTimeType"
                                                     minOccurs = "0"/>
       <xsd:element name = "PersonnelCapability"     type = "OpPersonnelCapabilityType" 
                                                     minOccurs = "0" maxOccurs = "unbounded"/>
@@ -152,11 +153,11 @@
                                                     minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "HierarchyScope"          type = "HierarchyScopeType"
                                                     minOccurs = "0" maxOccurs = "unbounded"/>
-      <xsd:element name = "StartTime"               type = "StartTimeType"
+      <xsd:element name = "StartTime"               type = "DateTimeType"
                                                     minOccurs = "0"/>
-      <xsd:element name = "EndTime"                 type = "EndTimeType"
+      <xsd:element name = "EndTime"                 type = "DateTimeType"
                                                     minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"           type = "PublishedDateType"
+      <xsd:element name = "PublishedDate"           type = "DateTimeType"
                                                     minOccurs = "0"/>
       <xsd:element name = "PersonnelCapability"     type = "OpPersonnelCapabilityType" 
                                                     minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/B2MML-WorkDefinition.xsd
+++ b/Schema/B2MML-WorkDefinition.xsd
@@ -60,6 +60,7 @@
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 4
                                                 Added unbounded to OperationsDefinitionID to WorkDefinitionType
                                                 Added OperationsSegmentID to WorkDefinitionType
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -110,7 +111,7 @@
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"
 														minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
 														minOccurs = "0"/>
       <xsd:element name = "WorkMaster"                  type = "WorkMasterType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
@@ -137,7 +138,7 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "Duration"                    type = "DurationType" 
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType"     
+      <xsd:element name = "PublishedDate"               type = "DateTimeType"     
                                                         minOccurs = "0"/>
       <xsd:element name = "OperationsDefinitionID"      type = "OperationsDefinitionIDType"     
                                                         minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/B2MML-WorkPerformance.xsd
+++ b/Schema/B2MML-WorkPerformance.xsd
@@ -111,13 +111,13 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkScheduleID"              type = "WorkScheduleIDType" 
                                                         minOccurs = "0"/>
-      <xsd:element name = "StartTime"                   type = "StartTimeType"                  
+      <xsd:element name = "StartTime"                   type = "DateTimeType"                  
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "EndTimeType"    
+      <xsd:element name = "EndTime"                     type = "DateTimeType"    
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkState"                   type = "ResponseStateType"
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkResponse"                type = "WorkResponseType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
@@ -140,9 +140,9 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkRequestID"              type = "WorkRequestIDType" 
                                                         minOccurs = "0"/>
-      <xsd:element name = "StartTime"                   type = "StartTimeType"          
+      <xsd:element name = "StartTime"                   type = "DateTimeType"          
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "EndTimeType"    
+      <xsd:element name = "EndTime"                     type = "DateTimeType"    
                                                         minOccurs = "0"/>
       <xsd:element name = "ResponseState"               type = "ResponseStateType"
                                                         minOccurs = "0"/>
@@ -178,9 +178,9 @@
                                                         minOccurs = "0" />
       <xsd:element name = "WorkflowSpecificationNoewID" type = "IdentifierType"    
                                                         minOccurs = "0" />
-      <xsd:element name = "StartTime"                   type = "ActualStartTimeType"    
+      <xsd:element name = "StartTime"                   type = "DateTimeType"    
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "ActualEndTimeType"      
+      <xsd:element name = "EndTime"                     type = "DateTimeType"      
                                                         minOccurs = "0"/>
       <xsd:element name = "JobState"                    type = "ResponseStateType"
                                                         minOccurs = "0"/>
@@ -211,9 +211,9 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkType"                    type = "OperationsTypeType"   
                                                         minOccurs = "0"/>
-      <xsd:element name = "StartTime"                   type = "ActualStartTimeType"    
+      <xsd:element name = "StartTime"                   type = "DateTimeType"    
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "ActualEndTimeType"      
+      <xsd:element name = "EndTime"                     type = "DateTimeType"      
                                                         minOccurs = "0"/>
       <xsd:element name = "JobState"                    type = "ResponseStateType"
                                                         minOccurs = "0"/>

--- a/Schema/B2MML-WorkSchedule.xsd
+++ b/Schema/B2MML-WorkSchedule.xsd
@@ -59,6 +59,7 @@
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 4
                                                 Added OperationsRequestID to JobOrderType
                                                 Added SegmentRequirementID to JobOrderType
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -103,13 +104,13 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkType"                    type = "OperationsTypeType"   
                                                         minOccurs = "0"/>
-      <xsd:element name = "StartTime"                   type = "StartTimeType"   
+      <xsd:element name = "StartTime"                   type = "DateTimeType"   
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "EndTimeType"     
+      <xsd:element name = "EndTime"                     type = "DateTimeType"     
                                                         minOccurs = "0"/>
       <xsd:element name = "ScheduleState"               type = "RequestStateType"
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkSchedule"                type = "WorkScheduleType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
@@ -129,9 +130,9 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "Workype"                     type = "OperationsTypeType"   
                                                         minOccurs = "0"/>
-      <xsd:element name = "StartTime"                   type = "StartTimeType" 
+      <xsd:element name = "StartTime"                   type = "DateTimeType" 
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "EndTimeType" 
+      <xsd:element name = "EndTime"                     type = "DateTimeType" 
                                                         minOccurs = "0"/>
       <xsd:element name = "Priority"                    type = "PriorityType" 
                                                         minOccurs = "0"/>
@@ -159,11 +160,11 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "Workype"                     type = "OperationsTypeType"   
                                                         minOccurs = "0"/>
-      <xsd:element name = "StartTime"                   type = "StartTimeType" 
+      <xsd:element name = "StartTime"                   type = "DateTimeType" 
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "EndTimeType" 
+      <xsd:element name = "EndTime"                     type = "DateTimeType" 
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"/>
       <xsd:element name = "JobOrder"                    type = "JobOrderType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
@@ -185,9 +186,9 @@
 	                                                    minOccurs = "0"/>
       <xsd:element name = "WorkMasterVersion"           type = "VersionType" 
 	                                                    minOccurs = "0"/>
-      <xsd:element name = "StartTime"                   type = "StartTimeType"  
+      <xsd:element name = "StartTime"                   type = "DateTimeType"  
                                                         minOccurs = "0"/>
-      <xsd:element name = "EndTime"                     type = "EndTimeType"      
+      <xsd:element name = "EndTime"                     type = "DateTimeType"      
                                                         minOccurs = "0"/>
       <xsd:element name = "Priority"                    type = "PriorityType" 
 	                                                    minOccurs = "0"/>

--- a/Schema/B2MML-WorkflowSpecification.xsd
+++ b/Schema/B2MML-WorkflowSpecification.xsd
@@ -57,6 +57,7 @@
         ---     ----            ------          ----
         V0600   17 Mar 2013     D. Brandl       Initial version with support for ISA 95 Part 4                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version for 2018 update of ISA 95 Part 4
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -106,7 +107,7 @@
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"
 														minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
 														minOccurs = "0"/>
       <xsd:element name = "WorkflowSpecification"       type = "WorkflowSpecificationType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/BatchML-BatchInformation.xsd
+++ b/Schema/BatchML-BatchInformation.xsd
@@ -217,10 +217,10 @@
       <xsd:element name = "ProductID"           type = "ProductIDType"          minOccurs = "0"/>
       <xsd:element name = "OrderID"             type = "OrderIDType"            minOccurs = "0"/>
       <xsd:element name = "StartCondition"      type = "StartConditionType"     minOccurs = "0"/>
-      <xsd:element name = "RequestedStartTime"  type = "RequestedStartTimeType" minOccurs = "0"/>
-      <xsd:element name = "ActualStartTime"     type = "ActualStartTimeType"    minOccurs = "0"/>
-      <xsd:element name = "RequestedEndTime"    type = "RequestedEndTimeType"   minOccurs = "0"/>
-      <xsd:element name = "ActualEndTime"       type = "ActualEndTimeType"      minOccurs = "0"/>
+      <xsd:element name = "RequestedStartTime"  type = "DateTimeType"           minOccurs = "0"/>
+      <xsd:element name = "ActualStartTime"     type = "DateTimeType"           minOccurs = "0"/>
+      <xsd:element name = "RequestedEndTime"    type = "DateTimeType"           minOccurs = "0"/>
+      <xsd:element name = "ActualEndTime"       type = "DateTimeType"           minOccurs = "0"/>
       <xsd:element name = "BatchPriority"       type = "BatchPriorityType"      minOccurs = "0"/>
       <xsd:element name = "RequestedBatchSize"  type = "RequestedBatchSizeType" minOccurs = "0"/>
       <xsd:element name = "ActualBatchSize"     type = "ActualBatchSizeType"    minOccurs = "0"/>
@@ -1332,10 +1332,10 @@
 
         <xsd:element name = "ActualBatchSize"           type = "ActualBatchSizeType"/>
         <xsd:element name = "ActualEquipmentID"         type = "ActualEquipmentIDType"/>
-        <xsd:element name = "ActualEndTime"             type = "ActualEndTimeType"/>
-        <xsd:element name = "ActualStartTime"           type = "ActualStartTimeType"/>
+        <xsd:element name = "ActualEndTime"             type = "DateTimeType"/>
+        <xsd:element name = "ActualStartTime"           type = "DateTimeType"/>
         <xsd:element name = "ApprovedBy"                type = "ApprovedByType"/>
-        <xsd:element name = "ApprovalDate"              type = "ApprovalDateType"/>
+        <xsd:element name = "ApprovalDate"              type = "DateTimeType"/>
         <xsd:element name = "ApprovalHistory"           type = "ApprovalHistoryType"/>
         <xsd:element name = "Author"                    type = "AuthorType"/>
 

--- a/Schema/BatchML-GeneralRecipe.xsd
+++ b/Schema/BatchML-GeneralRecipe.xsd
@@ -53,6 +53,7 @@
         V0500   26 Mar 2011     D. Brandl       Initial version
         V0600   17 Mar 2013     D. Brandl       Changed copyright to MESA International and support for ISA 95 Part 4                                 
         V0700   21 Dec 2018     D. Brandl       Updated Version
+												Changed all intermediate date and time types to DatTimeType
 
    </xsd:documentation>
 </xsd:annotation>
@@ -115,7 +116,7 @@
                                                         minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"    
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"/>
       <xsd:element name = "ResourceConstraintSpec"      type = "ResourceConstraintType"
                                                         minOccurs="0" maxOccurs="unbounded"/>
@@ -136,7 +137,7 @@
                                                         minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"    
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"/>
       <xsd:element name = "ProcessElementSpec"          type = "ProcessElementType"
                                                         minOccurs="0" maxOccurs="unbounded"/>
@@ -159,7 +160,7 @@
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "HierarchyScope"              type = "HierarchyScopeType"    
                                                         minOccurs = "0"/>
-      <xsd:element name = "PublishedDate"               type = "PublishedDateType" 
+      <xsd:element name = "PublishedDate"               type = "DateTimeType" 
                                                         minOccurs = "0"/>
       <xsd:element name = "Recipe"                      type = "GRecipeType" 
                                                         minOccurs = "0" maxOccurs = "unbounded"/>


### PR DESCRIPTION
I removed the intermediate date time types, such as EndDateTime. This does not invalidate any existing B2MML documents.