### PR TITLE
Add Extension option to WorkDefinition

### DIFF
--- a/Schema/B2MML-Extensions.xsd
+++ b/Schema/B2MML-Extensions.xsd
@@ -895,6 +895,12 @@ of elements when used in an XML document.
 
 <!-- B2MML extension groups for WorkDefinition schema  -->
 
+        <xsd:group name = "WorkDefinition">
+                <xsd:sequence>
+                        <!-- add extended elements here -->
+                </xsd:sequence>
+        </xsd:group>
+
         <xsd:group name = "WorkDefinitionInformation">
                 <xsd:sequence>
                         <!-- add extended elements here -->

--- a/Schema/B2MML-WorkDefinition.xsd
+++ b/Schema/B2MML-WorkDefinition.xsd
@@ -147,6 +147,7 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkflowSpecification"       type = "WorkflowSpecificationType"
                                                         minOccurs = "0"/>
+      <xsd:group   ref  = "Extended:WorkDefinition" 	minOccurs = "0" maxOccurs = "1"/>
     </xsd:sequence>
   </xsd:group>
 


### PR DESCRIPTION
From Arno Claeys.
As in some cases, if not in most cases, extensions on WorkMaster also apply on WorkDirective, it would be convenient to also add a extensions group to WorkDefinition.
The proposed change is to add a common extension to the shared information between all WorkMasters and WorkDirectives.
This is not a breaking change. See three types of extensions in figure below.
![image](https://user-images.githubusercontent.com/16944002/218813501-e0307454-37b6-401c-b42d-050e3887178e.png)
