### PR TITLE
Add WorkMasterVersion attribute

### DIFF
--- a/Schema/B2MML-WorkDefinition.xsd
+++ b/Schema/B2MML-WorkDefinition.xsd
@@ -175,6 +175,8 @@
     <xsd:sequence>
       <xsd:group   ref  = "WorkDefinitionType"/>
       <xsd:element name = "WorkMasterID"                type = "IdentifierType"/>
+      <xsd:element name = "WorkMasterVersion"           type = "IdentifierType"
+                                                        minOccurs = "0"/>
       <xsd:element name = "WorkDirectiveChild"          type = "WorkDirectiveType"
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "WorkDirectiveState"          type = "ResponseStateType"

--- a/Schema/B2MML-WorkflowSpecification.xsd
+++ b/Schema/B2MML-WorkflowSpecification.xsd
@@ -169,13 +169,13 @@
       <xsd:element name = "WorkflowSpecification"       type = "WorkflowSpecificationType"
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkMasterID"                type = "IdentifierType"
-                                                        minOccurs = "0"/>
+                                                        minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "WorkMasterVersion"           type = "IdentifierType"
-                                                        minOccurs = "0"/>
+                                                        minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "WorkDirectiveID"             type = "IdentifierType"
-                                                        minOccurs = "0"/>
+                                                        minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "WorkDirectiveVersion"        type = "IdentifierType"
-                                                        minOccurs = "0"/>                                                        
+                                                        minOccurs = "0" maxOccurs = "unbounded"/>                                                        
       <xsd:element name = "WorkflowSpecifictionNodeProperty"
                                                         type = "WorkflowSpecificationNodePropertyType"
                                                         minOccurs = "0" maxOccurs = "unbounded"/>

--- a/Schema/B2MML-WorkflowSpecification.xsd
+++ b/Schema/B2MML-WorkflowSpecification.xsd
@@ -170,6 +170,8 @@
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkMasterID"                type = "IdentifierType"
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
+      <xsd:element name = "WorkMasterVersion"           type = "IdentifierType"
+                                                        minOccurs = "0"/>
       <xsd:element name = "WorkDirectiveID"             type = "IdentifierType"
                                                         minOccurs = "0" maxOccurs = "unbounded"/>
       <xsd:element name = "WorkflowSpecifictionNodeProperty"

--- a/Schema/B2MML-WorkflowSpecification.xsd
+++ b/Schema/B2MML-WorkflowSpecification.xsd
@@ -169,11 +169,13 @@
       <xsd:element name = "WorkflowSpecification"       type = "WorkflowSpecificationType"
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkMasterID"                type = "IdentifierType"
-                                                        minOccurs = "0" maxOccurs = "unbounded"/>
+                                                        minOccurs = "0"/>
       <xsd:element name = "WorkMasterVersion"           type = "IdentifierType"
                                                         minOccurs = "0"/>
       <xsd:element name = "WorkDirectiveID"             type = "IdentifierType"
-                                                        minOccurs = "0" maxOccurs = "unbounded"/>
+                                                        minOccurs = "0"/>
+      <xsd:element name = "WorkDirectiveVersion"        type = "IdentifierType"
+                                                        minOccurs = "0"/>                                                        
       <xsd:element name = "WorkflowSpecifictionNodeProperty"
                                                         type = "WorkflowSpecificationNodePropertyType"
                                                         minOccurs = "0" maxOccurs = "unbounded"/>


### PR DESCRIPTION
For a WorkDirectiveType and a WorkflowSpecificationNodeType, there is a reference to a WorkMasterType via the WorkMasterID field, but an optional reference to the WorkMasterVersion is missing. 

A WorkDirectiveType already has a field for Version, but I assume it corresponds to the WorkDirective itself and not to the referred WorkMaster. 

Therefore, I propose two changes:
- Add WorkMasterVersion to WorkDirectiveType
- Add WorkMasterVersion to WorkflowSpecificationNodeType